### PR TITLE
Feat/holiday service

### DIFF
--- a/services/public_holidays.py
+++ b/services/public_holidays.py
@@ -1,0 +1,23 @@
+"""
+Returns the public holidays of the
+upcoming month for the schedule_maker
+"""
+import holidays
+from datetime import date
+from typing import List, Dict, Any
+
+
+def get_holidays_in_range(
+        country_code: str,
+        start_date: date,
+        end_date: date) -> List[Dict[str, Any]]:
+    """
+    Get holidays between start and end date
+    """
+    all_holidays = holidays.country_holidays(
+        country_code,
+        year=start_date.year)
+
+    return [{"date": holiday_date, "title": all_holidays[holiday_date]}
+            for holiday_date in all_holidays
+            if start_date <= holiday_date <= end_date]

--- a/services/public_holidays.py
+++ b/services/public_holidays.py
@@ -16,8 +16,20 @@ def get_holidays_in_range(
     """
     all_holidays = holidays.country_holidays(
         country_code,
-        year=start_date.year)
+        years=start_date.year)
 
     return [{"date": holiday_date, "title": all_holidays[holiday_date]}
             for holiday_date in all_holidays
             if start_date <= holiday_date <= end_date]
+
+
+# # testing
+# if __name__ == "__main__":
+#     # Test with Austrian holidays for August 2025
+#     august_holidays = get_holidays_in_range(
+#         'AT', date(2025, 8, 1), date(2025, 8, 31)
+#         )
+
+#     print(f"Found {len(august_holidays)} holidays in August 2025:")
+#     for holiday in august_holidays:
+#         print(f"  {holiday['date']}: {holiday['title']}")

--- a/services/shift_calendar.py
+++ b/services/shift_calendar.py
@@ -6,7 +6,7 @@ active employees are fetched and published.
 
 from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
-from datetime import datetime, date, time, timedelta
+from datetime import datetime, date, time
 from typing import List, Dict
 from dateutil.parser import parse
 import calendar

--- a/services/shift_calendar.py
+++ b/services/shift_calendar.py
@@ -134,7 +134,8 @@ class ShiftCalendar:
 #     shifts = cal.fetch_current_shifts()
 #     print(shifts)
 
-#     # To test publish, create a dummy schedule with the same keys as _parse_shift_event returns
+#     # To test publish, create a dummy schedule with the same keys as
+#       _parse_shift_event returns
 #     test_schedule = {
 #         "123": [
 #             {
@@ -142,13 +143,13 @@ class ShiftCalendar:
 #                 "start": datetime.now(),
 #                 "end": datetime.now() + timedelta(hours=8)
 #             }
-#         ], 
+#         ],
 #         "124": [
 #             {
 #                 "summary": "Test Shift 2",
 #                 "start": datetime.now(),
 #                 "end": datetime.now() + timedelta(hours=4)
 #             }
-#         ], 
+#         ],
 #     }
 #     cal.publish_upcoming_shifts(test_schedule)


### PR DESCRIPTION
## 🎯 Implement Public Holidays Module for Shift Scheduling

### Summary
Implements `public_holidays.py` module to fetch official public holidays for any country within a specified date range. This provides the foundation for applying holiday-specific rules in the shift assignment logic.

### What's New
- **New Module**: `services/public_holidays.py`
- **Function**: `get_holidays_in_range(country_code, start_date, end_date)`
- **Returns**: List of holiday dictionaries with date and title for easy processing

### Key Features
- ✅ Country-agnostic design (supports any ISO country code)
- ✅ Date range filtering for targeted queries  
- ✅ Clean data structure: `[{"date": date_obj, "title": "Holiday Name"}]`
- ✅ Ready for shift assignment integration

### Technical Implementation
- Uses `holidays` library for reliable, maintained holiday data
- Efficient filtering with list comprehension (no day-by-day iteration)
- Type hints for better code quality and IDE support

### Bug Fixes
- **Fixed**: `TypeError` with holidays library API
- **Solution**: Changed `year` parameter to `years` for proper compatibility
- **Root Cause**: holidays library API expects `years` not `year`

### Testing Results
```bash
$ python -m services.public_holidays
Found 1 holidays in August 2025:
  2025-08-15: Assumption Day